### PR TITLE
added options for symmetrization to take double of per point bandwidth

### DIFF
--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -97,8 +97,8 @@ class AdaptiveBwKDE(VariableBwKDEPy):
             The pilot KDE values at the data point positions.
         """
         self.set_bandwidth(
-                self.global_bandwidth / self._local_bandwidth_factor(pilot_values)
-                )
+            self.global_bandwidth / self._local_bandwidth_factor(pilot_values)
+         )
 
     def set_alpha(self, new_alpha):
         """

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -98,7 +98,7 @@ class AdaptiveBwKDE(VariableBwKDEPy):
         """
         self.set_bandwidth(
             self.global_bandwidth / self._local_bandwidth_factor(pilot_values)
-         )
+        )
 
     def set_alpha(self, new_alpha):
         """

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -96,7 +96,9 @@ class AdaptiveBwKDE(VariableBwKDEPy):
         pilot_values : array-like
             The pilot KDE values at the data point positions.
         """
-        self.set_bandwidth(self.global_bandwidth / self._local_bandwidth_factor(pilot_values))
+        self.set_bandwidth(
+                self.global_bandwidth / self._local_bandwidth_factor(pilot_values)
+                )
 
 
     def set_alpha(self, new_alpha):
@@ -295,13 +297,6 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         self.prepare_data()
         if self.symm_dims is not None:
             self.symmetrize_data(self.symm_dims)
-            # If bandwidth is per-point array, double it after symmetrization
-            if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
-                bw_array = np.asarray(self.bandwidth)
-                # Only double if it matches original data length (hasn't been doubled yet)
-                if bw_array.ndim == 1 and len(bw_array) == len(self.data):
-                    self.bandwidth = np.tile(bw_array, 2)
-
 
         # Re-initialize pilot KDE with new parameters and re-fit if requested
         self.pilot_kde = VariableBwKDEPy(self.data, self.weights, self.input_transf,

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -96,14 +96,7 @@ class AdaptiveBwKDE(VariableBwKDEPy):
         pilot_values : array-like
             The pilot KDE values at the data point positions.
         """
-        # Calculate bandwidth for each point
-        per_point_bw = self.global_bandwidth / self._local_bandwidth_factor(pilot_values)
-        # If data was symmetrized, double the bandwidth array to match doubled data
-        # Check if kde_data is doubled compared to original data
-        if hasattr(self, 'data') and len(self.kde_data) == 2 * len(self.data):
-            per_point_bw = np.tile(per_point_bw, 2)
-
-        self.set_bandwidth(per_point_bw)
+        self.set_bandwidth(self.global_bandwidth / self._local_bandwidth_factor(pilot_values))
 
 
     def set_alpha(self, new_alpha):

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -100,7 +100,6 @@ class AdaptiveBwKDE(VariableBwKDEPy):
                 self.global_bandwidth / self._local_bandwidth_factor(pilot_values)
                 )
 
-
     def set_alpha(self, new_alpha):
         """
         Set the adaptive parameter alpha to a new value and re-initialize KDE.

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -1,6 +1,7 @@
 import numpy as np
 from . import transform_utils as transf
 
+
 class SimpleKernelDensityEstimation:
     """
     Fit and evaluate multi-dimensional Kernel Density Estimation (KDE)

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -1,7 +1,6 @@
 import numpy as np
 from . import transform_utils as transf
 
-
 class SimpleKernelDensityEstimation:
     """
     Fit and evaluate multi-dimensional Kernel Density Estimation (KDE)
@@ -169,6 +168,8 @@ class SimpleKernelDensityEstimation:
         # If weights exist, also double the kde_weights array
         if self.weights is not None:
             self.kde_weights = np.tile(self.kde_weights, 2)
+
+
 
     def fit(self):
         """
@@ -420,6 +421,24 @@ class VariableBwKDEPy(SimpleKernelDensityEstimation):
         density_values = self.kernel_estimate.evaluate(points)
 
         return density_values
+
+    def symmetrize_data(self, dims):
+        """
+        Override parent method to also handle per-point bandwidth arrays.
+        Augment kde_data with a copy exchanging values between the two indexed
+        dimensions, and also double the bandwidth array if it's per-point.
+        """
+        # Call parent's symmetrize_data to handle data and weights
+        super().symmetrize_data(dims)
+
+        # Now handle bandwidth if it's an array
+        # Check if bandwidth is array-like (not a scalar)
+        if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
+            bw_array = np.asarray(self.bandwidth)
+            # Only double if it's a 1D array matching original data length
+            if bw_array.ndim == 1 and len(bw_array) == len(self.kde_data) // 2:
+                # Double the bandwidth array to match doubled data
+                self.bandwidth = np.tile(bw_array, 2)
 
 
 class MultiDimRescalingBwKDEPy(VariableBwKDEPy):

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -426,7 +426,7 @@ class VariableBwKDEPy(SimpleKernelDensityEstimation):
                     f"({len(self.data)}), got {len(bw)}"
                 )
 
-            # data was doubled by symmetrize_data, so bandwidth must be doubled too
+            # Duplicate bandwidth array to match the symmetrized data
             self.bandwidth = np.tile(bw, 2)
 
     def fit_KDEpy(self):

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -424,22 +424,16 @@ class VariableBwKDEPy(SimpleKernelDensityEstimation):
         return density_values
 
     def symmetrize_data(self, dims):
-        """
-        Override parent method to also handle per-point bandwidth arrays.
-        Augment kde_data with a copy exchanging values between the two indexed
-        dimensions, and also double the bandwidth array if it's per-point.
-        """
-        # Call parent's symmetrize_data to handle data and weights
-        super().symmetrize_data(dims)
+    """Symmetrize KDE data and, if needed, duplicate per-point bandwidths."""
+    super().symmetrize_data(dims)
 
-        # Now handle bandwidth if it's an array
-        # Check if bandwidth is array-like (not a scalar)
-        if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
-            bw_array = np.asarray(self.bandwidth)
-            # Only double if it's a 1D array matching original data length
-            if bw_array.ndim == 1 and len(bw_array) == len(self.kde_data) // 2:
-                # Double the bandwidth array to match doubled data
-                self.bandwidth = np.tile(bw_array, 2)
+    # If bandwidth is per-point, it must be duplicated to match doubled data
+    if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
+        bw = np.asarray(self.bandwidth)
+        original_n = len(self.kde_data) // 2
+
+        if bw.ndim == 1 and len(bw) == original_n:
+            self.bandwidth = np.tile(bw, 2)
 
 
 class MultiDimRescalingBwKDEPy(VariableBwKDEPy):

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -90,7 +90,6 @@ class SimpleKernelDensityEstimation:
             # Commented out as it's not clear if we ever need the 'unnormalized' case.
             self.normalize_weights()
         else:
-            # Initialize uniform weights if not provided
             self.kde_weights = None
 
         # Do transformation, standardize and rescale input data

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -409,6 +409,18 @@ class VariableBwKDEPy(SimpleKernelDensityEstimation):
         super().__init__(data, weights, input_transf, stdize, rescale,
                          symmetrize_dims, backend, bandwidth, dim_names, do_fit)
 
+    def symmetrize_data(self, dims):
+    """Symmetrize KDE data and, if needed, duplicate per-point bandwidths."""
+    super().symmetrize_data(dims)
+
+    # If bandwidth is per-point, it must be duplicated to match doubled data
+    if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
+        bw = np.asarray(self.bandwidth)
+        original_n = len(self.kde_data) // 2
+
+        if bw.ndim == 1 and len(bw) == original_n:
+            self.bandwidth = np.tile(bw, 2)
+
     def fit_KDEpy(self):
         from KDEpy.TreeKDE import TreeKDE
 
@@ -422,18 +434,6 @@ class VariableBwKDEPy(SimpleKernelDensityEstimation):
         density_values = self.kernel_estimate.evaluate(points)
 
         return density_values
-
-    def symmetrize_data(self, dims):
-    """Symmetrize KDE data and, if needed, duplicate per-point bandwidths."""
-    super().symmetrize_data(dims)
-
-    # If bandwidth is per-point, it must be duplicated to match doubled data
-    if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
-        bw = np.asarray(self.bandwidth)
-        original_n = len(self.kde_data) // 2
-
-        if bw.ndim == 1 and len(bw) == original_n:
-            self.bandwidth = np.tile(bw, 2)
 
 
 class MultiDimRescalingBwKDEPy(VariableBwKDEPy):

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -88,6 +88,9 @@ class SimpleKernelDensityEstimation:
             #if self.weights.max() > 100. or self.weights.max() < 0.01:
             # Commented out as it's not clear if we ever need the 'unnormalized' case.
             self.normalize_weights()
+        else:
+            # Initialize uniform weights if not provided
+            self.kde_weights = None
 
         # Do transformation, standardize and rescale input data
         self.prepare_data()

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -1,7 +1,6 @@
 import numpy as np
 from . import transform_utils as transf
 
-
 class SimpleKernelDensityEstimation:
     """
     Fit and evaluate multi-dimensional Kernel Density Estimation (KDE)
@@ -416,6 +415,7 @@ class VariableBwKDEPy(SimpleKernelDensityEstimation):
     # If bandwidth is per-point, it must be duplicated to match doubled data
     if isinstance(self.bandwidth, (list, tuple, np.ndarray)):
         bw = np.asarray(self.bandwidth)
+        assert bw_array.ndim == 1, "bandwidth must be a 1D per-point array"
         original_n = len(self.kde_data) // 2
 
         if bw.ndim == 1 and len(bw) == original_n:

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -172,8 +172,6 @@ class SimpleKernelDensityEstimation:
         if self.weights is not None:
             self.kde_weights = np.tile(self.kde_weights, 2)
 
-
-
     def fit(self):
         """
         General fit method allowing for different backends


### PR DESCRIPTION
I added a function in density_estimate script to take into account of symmetry for per-point-bandwidth and also modify adaptive script for two functions where we use perpoint bandwidth, which may not be needed but just to make sure it works.