### PR TITLE
Add  prior for rescaling factor optimization in KDERescaleOptimization (issue #39)

### DIFF
--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -350,7 +350,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Add bandwidth prior : -Nevents * beta * sum_p(ln(F_p)) = Nevents * beta * sum_p(ln(h_p))
         if self.bandwidth_prior is not None:
-            fom += -self.kde_data.shape[0] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
+            fom += -self.data.shape[0] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
 
         return -fom
 
@@ -389,13 +389,15 @@ class KDERescaleOptimization(AdaptiveBwKDE):
                                   bandwidth=self.bandwidth, alpha=alpha_val)
             # No need to symmetrize test data, as FOM values will be identical
             log_kde_eval = np.log(awkde.evaluate_with_transf(test_data))
+
             # Weighted sum of per-event log likelihoods
             fom.append((test_weights * log_kde_eval).sum())
+
 
         total_fom = sum(fom)
         # Add bandwidth prior
         if self.bandwidth_prior is not None:
-            total_fom += -self.kde_data.shape[0] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
+            total_fom += -self.data.shape[0] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
         
         return -total_fom
 

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -350,7 +350,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Add bandwidth prior term
         if self.bandwidth_prior_beta is not None:
-            fom += -self.data.shape[1] * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
+            fom += -self.kde_data.shape[0] * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
 
         return -fom
 
@@ -395,7 +395,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         total_fom = sum(fom)
         # Add bandwidth prior term
         if self.bandwidth_prior_beta is not None:
-            total_fom += -self.data.shape[1] * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
+            total_fom += -self.kde_data.shape[0] * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
         
         return -total_fom
 

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -350,7 +350,8 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Add bandwidth prior : -Nevents * beta * sum_p(ln(F_p)) = Nevents * beta * sum_p(ln(h_p))
         if self.bandwidth_prior is not None:
-            fom += -self.data.shape[0] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
+            fom += -self.data.shape[0] * self.bandwidth_prior * \
+                   np.sum(np.log(rescale_factors_alpha[:-1]))
 
         return -fom
 
@@ -393,11 +394,11 @@ class KDERescaleOptimization(AdaptiveBwKDE):
             # Weighted sum of per-event log likelihoods
             fom.append((test_weights * log_kde_eval).sum())
 
-
         total_fom = sum(fom)
         # Add bandwidth prior
         if self.bandwidth_prior is not None:
-            total_fom += -self.data.shape[0] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
+            total_fom += -self.data.shape[0] * self.bandwidth_prior * \
+                         np.sum(np.log(rescale_factors_alpha[:-1]))
         
         return -total_fom
 
@@ -550,4 +551,3 @@ class AdaptiveKDELeaveOneOutCrossValidation():
         kdeval = train_eval_kde(samples, x_eval, self.optbw, self.optalpha)
 
         return self.fom_val, self.optbw, self.optalpha
-

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -1,7 +1,6 @@
 import numpy as np
 import scipy
-#from .density_estimate import VariableBwKDEPy
-from density_estimate import VariableBwKDEPy
+from .density_estimate import VariableBwKDEPy
 from scipy.stats import gmean
 
 
@@ -351,7 +350,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Add bandwidth prior term
         if self.bandwidth_prior_beta is not None:
-            fom += -len(self.data)*self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
+            fom += -self.data.shape[1] * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
 
         return -fom
 
@@ -396,7 +395,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         total_fom = sum(fom)
         # Add bandwidth prior term
         if self.bandwidth_prior_beta is not None:
-            total_fom += -len(self.data) * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
+            total_fom += -self.data.shape[1] * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
         
         return -total_fom
 

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -348,7 +348,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
             # Weight is a length 1 array for LOO
             fom += test_weight[0] * np.log(awkde.evaluate_with_transf(test_data))
 
-        # Add bandwidth prior : Nevents * beta * sum_p(ln(F_p)) = Nevents * beta * sum_p(ln(h_p))
+        # Add bandwidth prior : -Nevents * beta * sum_p(ln(F_p)) = Nevents * beta * sum_p(ln(h_p))
         if self.bandwidth_prior is not None:
             fom += -self.data.shape[1] * self.bandwidth_prior * np.sum(np.log(rescale_factors_alpha[:-1]))
 

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy
-from .density_estimate import VariableBwKDEPy
+#from .density_estimate import VariableBwKDEPy
+from density_estimate import VariableBwKDEPy
 from scipy.stats import gmean
 
 
@@ -350,7 +351,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Add bandwidth prior term
         if self.bandwidth_prior_beta is not None:
-            fom += -self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
+            fom += -len(self.data)*self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
 
         return -fom
 
@@ -395,7 +396,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         total_fom = sum(fom)
         # Add bandwidth prior term
         if self.bandwidth_prior_beta is not None:
-            total_fom += -self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
+            total_fom += -len(self.data) * self.bandwidth_prior_beta * np.sum(np.log(rescale_factors_alpha[:-1]))
         
         return -total_fom
 


### PR DESCRIPTION
## Summary
Adds optional bandwidth prior penalty to cross-validation scoring in `KDERescaleOptimization` class to allow investigation and tuning of bandwidths during optimization.

## Changes
- Added `bandwidth_prior_beta` parameter to `__init__()` 
- Modified `loo_cv_score()` to include prior term: −β * Σ ln(rescale_val)
- Modified `kfold_cv_score()` to include prior term: −β * Σ ln(rescale_val)

## Implementation Details
The figure of merit now includes an optional power law prior factor:
```
FOM = log_likelihood + (−β * Σ_p ln(F_p))
```
where F_p = 1/h_p is the inverse bandwidth in dimension p.

- When `bandwidth_prior_beta=None` (default), behavior is unchanged
- Negative β values incentivize lower bandwidths
- Positive β values incentivize higher bandwidths

## Related Issue
Fixes #39

## Testing
- Backward compatible: default behavior unchanged when parameter not specified
- Works with both LOO-CV and k-fold CV methods