### PR TITLE
Add support for single-dimension reflection in symmetrize_data

### DIFF
--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -325,7 +325,6 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         alpha_val = rescale_factors_alpha[-1]
         # For 2-dim symmetrization, make another copy of the value for the first symm dimension
         # and insert it after this dim in the rescale array
-        # For 1-dim symmetrization (reflection), no special rescale treatment needed?
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescale_val[self.symm_dims[0]]
             rescale_val = np.insert(rescale_val, self.symm_dims[1], val_to_copy)
@@ -373,7 +372,6 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         alpha_val = rescale_factors_alpha[-1]
         # For 2-dim symmetrization, make another copy of the value for the first symm dimension
         # and insert it after this dim in the rescale array
-        # For 1-dim symmetrization (reflection), no special rescale treatment needed?
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescale_val[self.symm_dims[0]]
             rescale_val = np.insert(rescale_val, self.symm_dims[1], val_to_copy)
@@ -428,7 +426,6 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # For 2-dim symmetrization, check that the dimensions are treated the same and 
         # then remove one of them from the opt parameters
-        # For 1-dim symmetrization (reflection), no special treatment needed ?
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             firstdim = self.symm_dims[0]; secondim = self.symm_dims[1]
             assert init_rescale[firstdim] == init_rescale[secondim]
@@ -455,7 +452,6 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         # Set instance KDE parameters from the optimized results
         rescales = result.x[:-1]
         # For 2-dim symmetrization: copy the rescale value from first dim to second
-        # For 1-dim symmetrization: no special treatment needed ?
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescales[firstdim]
             rescales = np.insert(rescales, secondim, val_to_copy)

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -323,9 +323,10 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         """
         rescale_val = rescale_factors_alpha[:-1]
         alpha_val = rescale_factors_alpha[-1]
-        # For symmetrization, make another copy of the value for the first symm dimension
+        # For 2-dim symmetrization, make another copy of the value for the first symm dimension
         # and insert it after this dim in the rescale array
-        if self.symm_dims is not None:
+        # For 1-dim symmetrization (reflection), no special rescale treatment needed?
+        if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescale_val[self.symm_dims[0]]
             rescale_val = np.insert(rescale_val, self.symm_dims[1], val_to_copy)
 
@@ -370,9 +371,10 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         """
         rescale_val = rescale_factors_alpha[:-1]
         alpha_val = rescale_factors_alpha[-1]
-        # For symmetrization, make another copy of the value for the first symm dimension
+        # For 2-dim symmetrization, make another copy of the value for the first symm dimension
         # and insert it after this dim in the rescale array
-        if self.symm_dims is not None:
+        # For 1-dim symmetrization (reflection), no special rescale treatment needed?
+        if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescale_val[self.symm_dims[0]]
             rescale_val = np.insert(rescale_val, self.symm_dims[1], val_to_copy)
 
@@ -424,15 +426,15 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         # Insert alpha at the end of the array
         initial_choices = np.insert(init_rescale, init_rescale.size, init_alpha)
 
-        # For symmetrization, check that the dimensions are treated the same and 
+        # For 2-dim symmetrization, check that the dimensions are treated the same and 
         # then remove one of them from the opt parameters
-        if self.symm_dims is not None:
+        # For 1-dim symmetrization (reflection), no special treatment needed ?
+        if self.symm_dims is not None and len(self.symm_dims) == 2:
             firstdim = self.symm_dims[0]; secondim = self.symm_dims[1]
             assert init_rescale[firstdim] == init_rescale[secondim]
             assert bounds[firstdim] == bounds[secondim]
             initial_choices = np.delete(initial_choices, secondim)
             bounds = list(bounds); bounds.pop(secondim)
-
         try:
             score_fn = {
                 'kfold_cv': self.kfold_cv_score,
@@ -452,8 +454,9 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Set instance KDE parameters from the optimized results
         rescales = result.x[:-1]
-        # Symmetrization case: copy the rescale value from first dim to second
-        if self.symm_dims is not None:
+        # For 2-dim symmetrization: copy the rescale value from first dim to second
+        # For 1-dim symmetrization: no special treatment needed ?
+        if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescales[firstdim]
             rescales = np.insert(rescales, secondim, val_to_copy)
         self.set_rescale(rescales)

--- a/popde/adaptive_kde.py
+++ b/popde/adaptive_kde.py
@@ -323,7 +323,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         """
         rescale_val = rescale_factors_alpha[:-1]
         alpha_val = rescale_factors_alpha[-1]
-        # For 2-dim symmetrization, make another copy of the value for the first symm dimension
+        # For 2d symmetrization, make a copy of the value for the first symm dimension
         # and insert it after this dim in the rescale array
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescale_val[self.symm_dims[0]]
@@ -370,7 +370,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         """
         rescale_val = rescale_factors_alpha[:-1]
         alpha_val = rescale_factors_alpha[-1]
-        # For 2-dim symmetrization, make another copy of the value for the first symm dimension
+        # For 2d symmetrization, make a copy of the value for the first symm dimension
         # and insert it after this dim in the rescale array
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescale_val[self.symm_dims[0]]
@@ -424,7 +424,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
         # Insert alpha at the end of the array
         initial_choices = np.insert(init_rescale, init_rescale.size, init_alpha)
 
-        # For 2-dim symmetrization, check that the dimensions are treated the same and 
+        # For 2d symmetrization, check that the dimensions are treated the same and 
         # then remove one of them from the opt parameters
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             firstdim = self.symm_dims[0]; secondim = self.symm_dims[1]
@@ -451,7 +451,7 @@ class KDERescaleOptimization(AdaptiveBwKDE):
 
         # Set instance KDE parameters from the optimized results
         rescales = result.x[:-1]
-        # For 2-dim symmetrization: copy the rescale value from first dim to second
+        # For 2d symmetrization, copy the rescale value from first dim to second
         if self.symm_dims is not None and len(self.symm_dims) == 2:
             val_to_copy = rescales[firstdim]
             rescales = np.insert(rescales, secondim, val_to_copy)

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -1,6 +1,5 @@
 import numpy as np
 from . import transform_utils as transf
-import transform_utils as transf
 
 class SimpleKernelDensityEstimation:
     """
@@ -148,7 +147,7 @@ class SimpleKernelDensityEstimation:
             extra_data = []  # Build up 1-d arrays for the copy
             for d in range(self.ndim):
                 if d == d0:
-                    extra_data.append(self.kde_data[:, d1)])
+                    extra_data.append(self.kde_data[:, d1])
                 elif d == d1:
                     extra_data.append(self.kde_data[:, d0])
                 else:  # Leave other dimensions as they are

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -143,21 +143,23 @@ class SimpleKernelDensityEstimation:
         dims = list(dims)
 
         if len(dims) == 2:  # Swap two dimensions
+            d0 = int(dims[0]); d1 = int(dims[1])  # Only ints can be used for indexing
+            
             extra_data = []  # Build up 1-d arrays for the copy
             for d in range(self.ndim):
-                if d == int(dims[0]):
-                    extra_data.append(self.kde_data[:, int(dims[1])])
-                elif d == int(dims[1]):
-                    extra_data.append(self.kde_data[:, int(dims[0])])
+                if d == d0:
+                    extra_data.append(self.kde_data[:, d1)])
+                elif d == d1:
+                    extra_data.append(self.kde_data[:, d0])
                 else:  # Leave other dimensions as they are
                     extra_data.append(self.kde_data[:, d])
 
             extra_data = np.vstack(extra_data).T  # Stick arrays together
 
         elif len(dims) == 1:  # Reflect values across zero
-            dim_idx = dims[0]
+            d_id = int(dims[0])
             extra_data = self.kde_data.copy()
-            extra_data[:, dim_idx] = -extra_data[:, dim_idx]
+            extra_data[:, d_id] = -extra_data[:, d_id]
 
         else:
             raise ValueError(

--- a/popde/density_estimate.py
+++ b/popde/density_estimate.py
@@ -1,5 +1,6 @@
 import numpy as np
 from . import transform_utils as transf
+import transform_utils as transf
 
 class SimpleKernelDensityEstimation:
     """
@@ -139,10 +140,9 @@ class SimpleKernelDensityEstimation:
         - One dimension: Reflect values across zero in that dimension.
             Ex. ln(q) -> -ln(q) symmetry
         """
-        dims = list(dims) if not isinstance(dims, list) else dims
+        dims = list(dims)
 
-        if len(dims) == 2:
-            # Original behavior: swap two dimensions
+        if len(dims) == 2:  # Swap two dimensions
             extra_data = []  # Build up 1-d arrays for the copy
             for d in range(self.ndim):
                 if d == int(dims[0]):
@@ -154,9 +154,8 @@ class SimpleKernelDensityEstimation:
 
             extra_data = np.vstack(extra_data).T  # Stick arrays together
 
-        elif len(dims) == 1:
-            # New behavior: reflect single dimension across zero
-            dim_idx = int(dims[0])
+        elif len(dims) == 1:  # Reflect values across zero
+            dim_idx = dims[0]
             extra_data = self.kde_data.copy()
             extra_data[:, dim_idx] = -extra_data[:, dim_idx]
 


### PR DESCRIPTION
Extends the symmetrize_data method to support reflection symmetry in a single dimension, in addition to the existing two-dimension swap functionality based on issue #40.
### Motivation
The current symmetrize_data method only supports swapping values between two dimensions (e.g., m₁ ↔ m₂ symmetry). However, when masses are parameterized as ln(m_total) - ln(q) or ln(m_chirp) - ln(q), the physical symmetry manifests differently: ln(q) → -ln(q) while leaving m_total or m_chirp unchanged. This is a reflection across zero in a single dimension rather than a swap between two dimensions.

### Changes
Modified symmetrize_data to accept either 1 or 2 dimension indices
Two dimensions (existing behavior): Swaps values between the specified dimensions
One dimension (new behavior): Reflects values across zero for the specified dimension